### PR TITLE
Update to GnuCOBOL 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ RUN apt-get update -y
 RUN apt-get install wget gcc make -y
 RUN apt-get install libdb-dev libncurses5-dev libgmp-dev autoconf -y
 
-RUN wget https://s3.amazonaws.com/morecobol/gnucobol-3.0-rc1/gnucobol-3.0-rc1.tar.gz
+RUN wget https://s3.amazonaws.com/morecobol/gnucobol-3.0-rc1/gnucobol-3.0-rc1.tar.gz \
+         https://s3.amazonaws.com/morecobol/gnucobol-3.0-rc1/gnucobol-3.0-rc1.tar.gz.sig \
+         https://ftp.gnu.org/gnu/gnu-keyring.gpg
+RUN gpg --verify --keyring ./gnu-keyring.gpg gnucobol-3.0-rc1.tar.gz.sig
 RUN tar zxf gnucobol-3.0-rc1.tar.gz
 
 WORKDIR gnucobol-3.0-rc1

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update -y
 RUN apt-get install wget gcc make -y
 RUN apt-get install libdb-dev libncurses5-dev libgmp-dev autoconf -y
 
-RUN wget https://s3.amazonaws.com/cobol.run/gnu-cobol-2.0_rc-2.tar.gz
-RUN tar zxf gnu-cobol-2.0_rc-2.tar.gz
+RUN wget https://s3.amazonaws.com/morecobol/gnucobol-3.0-rc1/gnucobol-3.0-rc1.tar.gz
+RUN tar zxf gnucobol-3.0-rc1.tar.gz
 
-WORKDIR gnu-cobol-2.0
+WORKDIR gnucobol-3.0-rc1
 RUN ./configure
 RUN make
 RUN make install


### PR DESCRIPTION
Addresses issue #1.  
The result was tested with the example given in the README.md and worked:

    docker build -t gnucobol .
    docker run -ti gnucobol cobc -xj test.cob

As soon as gnucobol-3.0 is included in the standard gnu ftp server
one could switch to the generic gnu ftp mirror as the download source.  
E.g. http://ftpmirror.gnu.org/gnucobol/gnucobol-3.0-rc1.tar.gz

If there is anything you want changed, please let me know.